### PR TITLE
grammar tweak

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ const ssb = stack(config)
 ```js
 const content = {
   type: 'post',
-  test: 'kia ora whanau',
+  test: 'kia ora, e te whānau',
   recps: [ <GroupId>, <FeedId> ]
 }
 


### PR DESCRIPTION
Minor grammar change to Māori phrase. 
Reject this phrase if the phrase is intended to be spoken **in English** vs **in Māori**. A subtle difference as this post explains https://tearawhiti.wordpress.com/2016/10/07/kia-ora-te-whanau/