### PR TITLE
Fix deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3436,7 +3436,6 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ssb-schema-definitions/-/ssb-schema-definitions-3.2.1.tgz",
       "integrity": "sha512-+KBljo89bBi4gv3dnoiop4PexKLlySzq5bDcHvQ5aE4zXB8V33hocHuoJbihPr/jxry4kiqqo31TETwjV8YerQ==",
-      "dev": true,
       "requires": {
         "lodash.clone": "^4.5.0",
         "ssb-ref": "^2.14.0"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "envelope-js": "^0.1.2",
     "envelope-spec": "github:ssbc/envelope-spec",
     "futoin-hkdf": "^1.3.2",
-    "is-canonical-base64": "^1.1.1",
     "is-my-ssb-valid": "^1.1.0",
     "level": "^6.0.1",
     "lodash.set": "^4.3.2",
@@ -29,13 +28,14 @@
     "sodium-native": "^2.4.9",
     "ssb-keys": "^7.2.2",
     "ssb-ref": "^2.14.0",
+    "ssb-schema-definitions": "^3.1.0",
     "ssb-tangle": "^2.1.0"
   },
   "devDependencies": {
     "scuttle-testbot": "^1.2.3 ",
     "ssb-backlinks": "^2.0.1",
+    "is-canonical-base64": "^1.1.1",
     "ssb-query": "^2.4.5",
-    "ssb-schema-definitions": "^3.1.0",
     "standard": "^14.3.4",
     "tap-spec": "^5.0.0",
     "tape": "^4.13.3"


### PR DESCRIPTION
Problem: We didn't list ssb-schema-definitions as a dependency, which
means that when SSB-Tribes is `require()`ed by upstream code then it
immediately crashes. This is currently breaking SSB-DB.

Solution: Move ssb-schema-definitions from `devDependencies` to
`dependencies`.

---

I'm also merging in my segfault fix from #12 because it seems trivial and I can't think of a reason why we'd want to continue segfaulting Travis.