### PR TITLE
block previous re-use, access ssb.previous instead of ssb.post

### DIFF
--- a/envelope.js
+++ b/envelope.js
@@ -43,7 +43,14 @@ module.exports = function Envelope (keystore, state) {
     const plaintext = Buffer.from(JSON.stringify(content), 'utf8')
     const msgKey = new SecretKey().toBuffer()
 
-    const envelope = box(plaintext, state.feedId, state.previous, msgKey, recipentKeys)
+    if (!state.previous) throw new Error('previous not ready!')
+    // throwing here causes the publish to cb(err)
+    const _previous = state.previous
+    state.previous = undefined
+    // NOTE: clearing state.previous ensures that we never have two messages in our log
+    // which use the same previous value. We were seeing this with some bulk publishing
+
+    const envelope = box(plaintext, state.feedId, _previous, msgKey, recipentKeys)
     return envelope.toString('base64') + '.box2'
   }
 

--- a/listen.js
+++ b/listen.js
@@ -34,13 +34,14 @@ function previous (ssb) {
   )
 
   /* ongoing previous listening */
-  ssb.post(m => {
-    if (m.value.author !== ssb.id) {
-      return
-    }
+  // ssb.post(m => {
+  //   if (m.value.author !== ssb.id) {
+  //     return
+  //   }
 
-    set(m.key)
-  })
+  //   set(m.key)
+  // })
+  ssb.previous(id => set(id))
 
   return subscribe
 }


### PR DESCRIPTION
depends on https://github.com/ssbc/ssb-db/pull/311 being linked in