### PR TITLE
Refactor to remove previous listener and state 

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,10 +35,8 @@ function init (ssb, config) {
     keys: ssb.keys,
 
     feedId: new FeedId(ssb.id).toTFK(),
-    previous: undefined,
 
     loading: {
-      previous: true,
       keystore: true
     },
 
@@ -56,15 +54,8 @@ function init (ssb, config) {
 
   /* register the boxer / unboxer */
   const { boxer, unboxer } = Envelope(keystore, state)
-  ssb.addBoxer({ init: isBoxerReady, value: boxer })
+  ssb.addBoxer({ value: boxer })
   ssb.addUnboxer({ init: isUnboxerReady, ...unboxer })
-
-  function isBoxerReady (done) {
-    if (state.loading.previous === false) return done()
-    if (state.closed === false) {
-      setTimeout(() => isBoxerReady(done), 500)
-    }
-  }
 
   function isUnboxerReady (done) {
     if (state.loading.keystore === false) return done()
@@ -74,10 +65,6 @@ function init (ssb, config) {
   }
 
   /* start listeners */
-  listen.previous(ssb)(prev => {
-    state.previous = prev
-    if (state.loading.previous) state.loading.previous = false
-  })
   listen.addMember(ssb)(m => {
     const { root, groupKey } = m.value.content
     ssb.get({ id: root, meta: true }, (err, groupInitMsg) => {

--- a/listen.js
+++ b/listen.js
@@ -1,49 +1,8 @@
 const pull = require('pull-stream')
-const { MsgId } = require('./lib/cipherlinks')
 const { isValid } = require('./spec/group/add-member')
 
 module.exports = {
-  previous,
   addMember
-}
-
-function previous (ssb) {
-  var listeners = []
-  var prev = undefined // eslint-disable-line
-
-  function subscribe (listener) {
-    listeners.push(listener)
-    if (prev !== undefined) listener(prev)
-    // immediately emits current value (if it exists) for new subscribers
-  }
-
-  function set (msgIdOrNull) {
-    prev = new MsgId(msgIdOrNull).toTFK()
-    listeners.forEach(fn => fn(prev))
-  }
-
-  /* initial previous lookup */
-  // TODO - research which is most direct source for this initial load
-  pull(
-    ssb.createUserStream({ id: ssb.id, reverse: true, limit: 1 }),
-    pull.collect((err, msgs) => {
-      if (err) throw err
-
-      set(msgs.length ? msgs[0].key : null)
-    })
-  )
-
-  /* ongoing previous listening */
-  // ssb.post(m => {
-  //   if (m.value.author !== ssb.id) {
-  //     return
-  //   }
-
-  //   set(m.key)
-  // })
-  ssb.previous(id => set(id))
-
-  return subscribe
 }
 
 function addMember (ssb) {

--- a/method/group/init.js
+++ b/method/group/init.js
@@ -1,18 +1,13 @@
 const { box } = require('envelope-js')
 const { keySchemes } = require('private-group-spec')
 
+const { MsgId } = require('../../lib/cipherlinks')
 const Secret = require('../../lib/secret-key')
 const groupId = require('../../lib/group-id')
 const { isValid } = require('../../spec/group/init')
 
-module.exports = function GroupCreate (ssb, _, state) {
+module.exports = function GroupCreate (ssb, keystore, state) {
   return function groupCreate (cb) {
-    if (state.loading.previous) {
-      // TODO 2020-07-31 - maybe we should check state.previous instead
-      setTimeout(() => groupCreate(cb), 500)
-      return
-    }
-
     const groupKey = new Secret()
     const content = {
       type: 'group/init',
@@ -37,18 +32,24 @@ module.exports = function GroupCreate (ssb, _, state) {
     //   - need to check if it's safe to make a sharedDM with oneself
     // would also require adding groupKey to this message
 
-    const envelope = box(plain, state.feedId, state.previous, msgKey, recipientKeys)
-    const ciphertext = envelope.toString('base64') + '.box2'
-
-    ssb.publish(ciphertext, (err, groupInitMsg) => {
+    ssb.getFeedState(ssb.id, (err, previousFeedState) => {
       if (err) return cb(err)
 
-      const data = {
-        groupId: groupId({ groupInitMsg, msgKey }),
-        groupKey: groupKey.toBuffer(),
-        groupInitMsg
-      }
-      cb(null, data)
+      const previousMessageId = new MsgId(previousFeedState.id).toTFK()
+
+      const envelope = box(plain, state.feedId, previousMessageId, msgKey, recipientKeys)
+      const ciphertext = envelope.toString('base64') + '.box2'
+
+      ssb.publish(ciphertext, (err, groupInitMsg) => {
+        if (err) return cb(err)
+
+        const data = {
+          groupId: groupId({ groupInitMsg, msgKey }),
+          groupKey: groupKey.toBuffer(),
+          groupInitMsg
+        }
+        cb(null, data)
+      })
     })
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -76,7 +76,6 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/aligned-block-file/-/aligned-block-file-1.2.2.tgz",
       "integrity": "sha512-2Sy0hWhifVb8ycNFJgicL8fDPL2Ct1r62XOVxXnykn36z22MPZwnQlCmB2viQlY/lwfuO67GaQjUZ0rJgdVP7Q==",
-      "dev": true,
       "requires": {
         "hashlru": "^2.1.0",
         "int53": "^1.0.0",
@@ -90,7 +89,6 @@
           "version": "0.5.5",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
           "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-          "dev": true,
           "requires": {
             "minimist": "^1.2.5"
           }
@@ -132,8 +130,7 @@
     "append-batch": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/append-batch/-/append-batch-0.0.2.tgz",
-      "integrity": "sha1-1zm0UDiIJF1Hkz1HVisRSf+d+Lc=",
-      "dev": true
+      "integrity": "sha1-1zm0UDiIJF1Hkz1HVisRSf+d+Lc="
     },
     "argparse": {
       "version": "1.0.10",
@@ -170,20 +167,12 @@
     "async-single": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/async-single/-/async-single-1.0.5.tgz",
-      "integrity": "sha1-El3QneldPqMKN4rb7QIQkhebA8k=",
-      "dev": true
-    },
-    "async-write": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/async-write/-/async-write-2.1.0.tgz",
-      "integrity": "sha1-HnYoF9hJzkS/rAeSWkIDZ4cGGxU=",
-      "dev": true
+      "integrity": "sha1-El3QneldPqMKN4rb7QIQkhebA8k="
     },
     "atomic-file": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/atomic-file/-/atomic-file-2.0.1.tgz",
       "integrity": "sha512-9JCWojeLDF8UhEv2UJlLlPGsLEs+EBnfB+kOhsvmFI2QilVrnIsAwr7YnF8lLEVuxB+HxFhvGK+ax0Y8Eh/BKA==",
-      "dev": true,
       "requires": {
         "flumecodec": "0.0.1",
         "idb-kv-store": "^4.4.0"
@@ -193,7 +182,6 @@
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/flumecodec/-/flumecodec-0.0.1.tgz",
           "integrity": "sha1-rgSacUOGu4PjQmV6gpJLcDZKkNY=",
-          "dev": true,
           "requires": {
             "level-codec": "^6.2.0"
           }
@@ -201,8 +189,7 @@
         "level-codec": {
           "version": "6.2.0",
           "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-6.2.0.tgz",
-          "integrity": "sha1-pLUkS7akwvcj1oodZOmAxTYn2dQ=",
-          "dev": true
+          "integrity": "sha1-pLUkS7akwvcj1oodZOmAxTYn2dQ="
         }
       }
     },
@@ -218,8 +205,7 @@
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-      "dev": true
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "base64-js": {
       "version": "1.3.1",
@@ -242,7 +228,6 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -368,14 +353,12 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "cont": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/cont/-/cont-1.0.3.tgz",
       "integrity": "sha1-aHTx6TX8qZ0EjK6qrZoK6wILzOA=",
-      "dev": true,
       "requires": {
         "continuable": "~1.2.0",
         "continuable-para": "~1.2.0",
@@ -391,14 +374,12 @@
     "continuable": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/continuable/-/continuable-1.2.0.tgz",
-      "integrity": "sha1-CCd0aNQRNiAAdMz4cpQwjRafJbY=",
-      "dev": true
+      "integrity": "sha1-CCd0aNQRNiAAdMz4cpQwjRafJbY="
     },
     "continuable-hash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/continuable-hash/-/continuable-hash-0.1.4.tgz",
       "integrity": "sha1-gcdNQXcdjJJ4Ph4A5fEbNNbfx4w=",
-      "dev": true,
       "requires": {
         "continuable": "~1.1.6"
       },
@@ -406,8 +387,7 @@
         "continuable": {
           "version": "1.1.8",
           "resolved": "https://registry.npmjs.org/continuable/-/continuable-1.1.8.tgz",
-          "integrity": "sha1-3Id7R0FghwrjvN6HM2Jo6+UFl9U=",
-          "dev": true
+          "integrity": "sha1-3Id7R0FghwrjvN6HM2Jo6+UFl9U="
         }
       }
     },
@@ -415,7 +395,6 @@
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/continuable-list/-/continuable-list-0.1.6.tgz",
       "integrity": "sha1-h88G7FgHFuEN/5X7C4TF8OisrF8=",
-      "dev": true,
       "requires": {
         "continuable": "~1.1.6"
       },
@@ -423,8 +402,7 @@
         "continuable": {
           "version": "1.1.8",
           "resolved": "https://registry.npmjs.org/continuable/-/continuable-1.1.8.tgz",
-          "integrity": "sha1-3Id7R0FghwrjvN6HM2Jo6+UFl9U=",
-          "dev": true
+          "integrity": "sha1-3Id7R0FghwrjvN6HM2Jo6+UFl9U="
         }
       }
     },
@@ -432,7 +410,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/continuable-para/-/continuable-para-1.2.0.tgz",
       "integrity": "sha1-RFUQ9klFndD8NchyAVFGEicxxYM=",
-      "dev": true,
       "requires": {
         "continuable-hash": "~0.1.4",
         "continuable-list": "~0.1.5"
@@ -441,8 +418,7 @@
     "continuable-series": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/continuable-series/-/continuable-series-1.2.0.tgz",
-      "integrity": "sha1-MkM5euk6cdZVswJoNKUVkLlYueg=",
-      "dev": true
+      "integrity": "sha1-MkM5euk6cdZVswJoNKUVkLlYueg="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -482,7 +458,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
       "integrity": "sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==",
-      "dev": true,
       "requires": {
         "is-arguments": "^1.0.4",
         "is-date-object": "^1.0.1",
@@ -511,7 +486,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
       "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
-      "dev": true,
       "requires": {
         "object-keys": "^1.0.12"
       }
@@ -634,7 +608,6 @@
       "version": "1.17.6",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
       "integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
-      "dev": true,
       "requires": {
         "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
@@ -668,7 +641,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
       "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
-      "dev": true,
       "requires": {
         "is-callable": "^1.1.4",
         "is-date-object": "^1.0.1",
@@ -1030,8 +1002,7 @@
     "explain-error": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/explain-error/-/explain-error-1.0.4.tgz",
-      "integrity": "sha1-p5PTrAytTGq1cemWj7urbLJTKSk=",
-      "dev": true
+      "integrity": "sha1-p5PTrAytTGq1cemWj7urbLJTKSk="
     },
     "external-editor": {
       "version": "3.1.0",
@@ -1127,7 +1098,6 @@
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/flumecodec/-/flumecodec-0.0.0.tgz",
       "integrity": "sha1-Ns4Gq+Lg4BxE3WnyoWUwWiMgZJs=",
-      "dev": true,
       "requires": {
         "level-codec": "^6.2.0"
       },
@@ -1135,8 +1105,7 @@
         "level-codec": {
           "version": "6.2.0",
           "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-6.2.0.tgz",
-          "integrity": "sha1-pLUkS7akwvcj1oodZOmAxTYn2dQ=",
-          "dev": true
+          "integrity": "sha1-pLUkS7akwvcj1oodZOmAxTYn2dQ="
         }
       }
     },
@@ -1144,7 +1113,6 @@
       "version": "2.1.8",
       "resolved": "https://registry.npmjs.org/flumedb/-/flumedb-2.1.8.tgz",
       "integrity": "sha512-MtBCZFjj9GuqOQP8Ld87FbXm8ztQyLkLeuiHuB5+aACFuVn1kunnCis75R03ujFZTqCFmkBwFz7E016b3DB0zA==",
-      "dev": true,
       "requires": {
         "cont": "^1.0.3",
         "explain-error": "^1.0.3",
@@ -1158,8 +1126,7 @@
         "pull-abortable": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/pull-abortable/-/pull-abortable-4.1.1.tgz",
-          "integrity": "sha1-s61a77QRayWRbSbbiTk6yY0NzqE=",
-          "dev": true
+          "integrity": "sha1-s61a77QRayWRbSbbiTk6yY0NzqE="
         }
       }
     },
@@ -1167,7 +1134,6 @@
       "version": "3.4.4",
       "resolved": "https://registry.npmjs.org/flumelog-offset/-/flumelog-offset-3.4.4.tgz",
       "integrity": "sha512-sakCD+dVx541h3VeVq3Ti2lWPRrJf8PBRmnbm9EMBVLJnZkS3UD2lAlClZROxgKbh/JkMPyffvhDGv4VHNCVbA==",
-      "dev": true,
       "requires": {
         "aligned-block-file": "^1.2.0",
         "append-batch": "0.0.2",
@@ -1184,8 +1150,7 @@
         "looper": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/looper/-/looper-4.0.0.tgz",
-          "integrity": "sha1-dwat7VmpntygbmtUu4bI7BnJUVU=",
-          "dev": true
+          "integrity": "sha1-dwat7VmpntygbmtUu4bI7BnJUVU="
         }
       }
     },
@@ -1193,7 +1158,6 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/flumeview-level/-/flumeview-level-4.0.4.tgz",
       "integrity": "sha512-8C/o/oZU73ot1LMbxCyKeZJ0D3L5AGdxzIF5H2QtmznMSoZHVG1gT2IDjkOtesenVPlLQKnL95ewMKbE7cXWEw==",
-      "dev": true,
       "requires": {
         "charwise": "^3.0.1",
         "explain-error": "^1.0.4",
@@ -1263,7 +1227,6 @@
       "version": "1.3.17",
       "resolved": "https://registry.npmjs.org/flumeview-reduce/-/flumeview-reduce-1.3.17.tgz",
       "integrity": "sha512-Li09TntlRpN51GtFKllIh5nDdBcyDazvi5a/yvbdUCS9xAFb8OA6H6uu32W9gG+4GyvfUi9AsOyN8RQ8OcREQA==",
-      "dev": true,
       "requires": {
         "async-single": "^1.0.5",
         "atomic-file": "^2.0.0",
@@ -1292,14 +1255,12 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
     "functional-red-black-tree": {
       "version": "1.0.1",
@@ -1338,7 +1299,6 @@
       "version": "7.1.6",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
       "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
-      "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -1376,7 +1336,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "dev": true,
       "requires": {
         "function-bind": "^1.1.1"
       }
@@ -1407,14 +1366,12 @@
     "has-symbols": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-      "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
-      "dev": true
+      "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
     },
     "hashlru": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/hashlru/-/hashlru-2.3.0.tgz",
-      "integrity": "sha512-0cMsjjIC8I+D3M44pOQdsy0OHXGLVz6Z0beRuufhKa0KfaD2wGwAev6jILzXsd3/vpnNQJmWyZtIILqM1N+n5A==",
-      "dev": true
+      "integrity": "sha512-0cMsjjIC8I+D3M44pOQdsy0OHXGLVz6Z0beRuufhKa0KfaD2wGwAev6jILzXsd3/vpnNQJmWyZtIILqM1N+n5A=="
     },
     "hoox": {
       "version": "0.0.1",
@@ -1441,7 +1398,6 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/idb-kv-store/-/idb-kv-store-4.4.0.tgz",
       "integrity": "sha1-IsVqjV+QvYj4GKhZ25xYYn3ieL4=",
-      "dev": true,
       "requires": {
         "inherits": "^2.0.3",
         "promisize": "^1.1.2"
@@ -1489,7 +1445,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -1590,8 +1545,7 @@
     "int53": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/int53/-/int53-1.0.0.tgz",
-      "integrity": "sha512-u8BMiMa05OPBgd32CKTead0CVTsFVgwFk23nNXo1teKPF6Sxcu0lXxEzP//zTcaKzXbGgPDXGmj/woyv+I4C5w==",
-      "dev": true
+      "integrity": "sha512-u8BMiMa05OPBgd32CKTead0CVTsFVgwFk23nNXo1teKPF6Sxcu0lXxEzP//zTcaKzXbGgPDXGmj/woyv+I4C5w=="
     },
     "ip": {
       "version": "1.1.5",
@@ -1601,8 +1555,7 @@
     "is-arguments": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.0.4.tgz",
-      "integrity": "sha512-xPh0Rmt8NE65sNzvyUmWgI1tz3mKq74lGA0mL8LYZcoIzKOzDh6HmrYm3d18k60nHerC8A9Km8kYu87zfSFnLA==",
-      "dev": true
+      "integrity": "sha512-xPh0Rmt8NE65sNzvyUmWgI1tz3mKq74lGA0mL8LYZcoIzKOzDh6HmrYm3d18k60nHerC8A9Km8kYu87zfSFnLA=="
     },
     "is-arrayish": {
       "version": "0.2.1",
@@ -1625,8 +1578,7 @@
     "is-callable": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.0.tgz",
-      "integrity": "sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw==",
-      "dev": true
+      "integrity": "sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw=="
     },
     "is-canonical-base64": {
       "version": "1.1.1",
@@ -1636,8 +1588,7 @@
     "is-date-object": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
-      "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==",
-      "dev": true
+      "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g=="
     },
     "is-electron": {
       "version": "2.2.0",
@@ -1718,7 +1669,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.0.tgz",
       "integrity": "sha512-iI97M8KTWID2la5uYXlkbSDQIg4F6o1sYboZKKTDpnDQMLtUL86zxhgDet3Q2SriaYsyGqZ6Mn2SjbRKeLHdqw==",
-      "dev": true,
       "requires": {
         "has-symbols": "^1.0.1"
       }
@@ -1739,7 +1689,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
       "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
-      "dev": true,
       "requires": {
         "has-symbols": "^1.0.1"
       }
@@ -2010,8 +1959,7 @@
     "lodash.clonedeep": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
-      "dev": true
+      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
     },
     "lodash.get": {
       "version": "4.4.2",
@@ -2082,7 +2030,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -2100,8 +2047,7 @@
     "monotonic-timestamp": {
       "version": "0.0.9",
       "resolved": "https://registry.npmjs.org/monotonic-timestamp/-/monotonic-timestamp-0.0.9.tgz",
-      "integrity": "sha1-W6Wtx6rIXh1853voRxYe0kazlgM=",
-      "dev": true
+      "integrity": "sha1-W6Wtx6rIXh1853voRxYe0kazlgM="
     },
     "moo": {
       "version": "0.5.1",
@@ -2178,7 +2124,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/muxrpc-validation/-/muxrpc-validation-3.0.2.tgz",
       "integrity": "sha512-iWo/23xFnl+IGeX+LlfwoVKtyY4volPSodf3nwPScPgxjws4k2ZUozPG98OouMA0yn0JamqApjRw7eqLrzyV2A==",
-      "dev": true,
       "requires": {
         "pull-stream": "^3.6.11",
         "zerr": "^1.0.4"
@@ -2253,14 +2198,12 @@
     "object-inspect": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.8.0.tgz",
-      "integrity": "sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA==",
-      "dev": true
+      "integrity": "sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA=="
     },
     "object-is": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.2.tgz",
       "integrity": "sha512-5lHCz+0uufF6wZ7CRFWJN3hp8Jqblpgve06U5CMQ3f//6iDjPr2PEo9MWCjEssDsa+UZEL4PkFpr+BMop6aKzQ==",
-      "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.5"
@@ -2269,14 +2212,12 @@
     "object-keys": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-      "dev": true
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
     },
     "object.assign": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
       "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
-      "dev": true,
       "requires": {
         "define-properties": "^1.1.2",
         "function-bind": "^1.1.1",
@@ -2322,20 +2263,17 @@
     "obv": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/obv/-/obv-0.0.1.tgz",
-      "integrity": "sha1-yyNhBjQVNvDaxIFeBnCCIcrX+14=",
-      "dev": true
+      "integrity": "sha1-yyNhBjQVNvDaxIFeBnCCIcrX+14="
     },
     "obz": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/obz/-/obz-1.0.2.tgz",
-      "integrity": "sha512-c+EtVwT2IpXz5we2mR40aPLJ1s0eNOsxYeaYbaHhmsY6kWKo3IRkpwpBU5ck0aHfqfKUUEiKabC6rzsrG/hSHw==",
-      "dev": true
+      "integrity": "sha512-c+EtVwT2IpXz5we2mR40aPLJ1s0eNOsxYeaYbaHhmsY6kWKo3IRkpwpBU5ck0aHfqfKUUEiKabC6rzsrG/hSHw=="
     },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -2448,8 +2386,7 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-key": {
       "version": "2.0.1",
@@ -2638,8 +2575,7 @@
     "promisize": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/promisize/-/promisize-1.1.2.tgz",
-      "integrity": "sha1-m0fiyyrkl+seutwsQZHWTRXJSdE=",
-      "dev": true
+      "integrity": "sha1-m0fiyyrkl+seutwsQZHWTRXJSdE="
     },
     "prop-types": {
       "version": "15.7.2",
@@ -2685,14 +2621,12 @@
     "pull-cont": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/pull-cont/-/pull-cont-0.1.1.tgz",
-      "integrity": "sha1-3x1YDicXV7qay666IN4kIdZg1hg=",
-      "dev": true
+      "integrity": "sha1-3x1YDicXV7qay666IN4kIdZg1hg="
     },
     "pull-cursor": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pull-cursor/-/pull-cursor-3.0.0.tgz",
       "integrity": "sha512-95lZVSF2eSEdOmUtlOBaD9p5YOvlYeCr5FBv2ySqcj/4rpaXI6d8OH+zPHHjKAf58R8QXJRZuyfHkcCX8TZbAg==",
-      "dev": true,
       "requires": {
         "looper": "^4.0.0",
         "ltgt": "^2.2.0",
@@ -2702,8 +2636,7 @@
         "looper": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/looper/-/looper-4.0.0.tgz",
-          "integrity": "sha1-dwat7VmpntygbmtUu4bI7BnJUVU=",
-          "dev": true
+          "integrity": "sha1-dwat7VmpntygbmtUu4bI7BnJUVU="
         }
       }
     },
@@ -2785,7 +2718,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/pull-looper/-/pull-looper-1.0.0.tgz",
       "integrity": "sha512-djlD60A6NGe5goLdP5pgbqzMEiWmk1bInuAzBp0QOH4vDrVwh05YDz6UP8+pOXveKEk8wHVP+rB2jBrK31QMPA==",
-      "dev": true,
       "requires": {
         "looper": "^4.0.0"
       },
@@ -2793,8 +2725,7 @@
         "looper": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/looper/-/looper-4.0.0.tgz",
-          "integrity": "sha1-dwat7VmpntygbmtUu4bI7BnJUVU=",
-          "dev": true
+          "integrity": "sha1-dwat7VmpntygbmtUu4bI7BnJUVU="
         }
       }
     },
@@ -2802,7 +2733,6 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/pull-notify/-/pull-notify-0.1.1.tgz",
       "integrity": "sha1-b4b/ldJwuJw+vyVbYDG3Ay3JnMo=",
-      "dev": true,
       "requires": {
         "pull-pushable": "^2.0.0"
       }
@@ -2817,7 +2747,6 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/pull-paramap/-/pull-paramap-1.2.2.tgz",
       "integrity": "sha1-UaQZPOnI1yFdla2tReK824STsjo=",
-      "dev": true,
       "requires": {
         "looper": "^4.0.0"
       },
@@ -2825,8 +2754,7 @@
         "looper": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/looper/-/looper-4.0.0.tgz",
-          "integrity": "sha1-dwat7VmpntygbmtUu4bI7BnJUVU=",
-          "dev": true
+          "integrity": "sha1-dwat7VmpntygbmtUu4bI7BnJUVU="
         }
       }
     },
@@ -2900,7 +2828,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/pull-write/-/pull-write-1.1.4.tgz",
       "integrity": "sha1-3d6jFJO0j2douEooHQHrO1Mf4Lg=",
-      "dev": true,
       "requires": {
         "looper": "^4.0.0",
         "pull-cat": "^1.1.11",
@@ -2910,8 +2837,7 @@
         "looper": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/looper/-/looper-4.0.0.tgz",
-          "integrity": "sha1-dwat7VmpntygbmtUu4bI7BnJUVU=",
-          "dev": true
+          "integrity": "sha1-dwat7VmpntygbmtUu4bI7BnJUVU="
         }
       }
     },
@@ -2993,7 +2919,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.3.0.tgz",
       "integrity": "sha512-2+Q0C5g951OlYlJz6yu5/M33IcsESLlLfsyIaLJaG4FA2r4yP8MvVMJUUP/fVBkSpbbbZlS5gynbEWLipiiXiQ==",
-      "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.0-next.1"
@@ -3060,7 +2985,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
       "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "dev": true,
       "requires": {
         "glob": "^7.1.3"
       }
@@ -3080,8 +3004,7 @@
     "rwlock": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/rwlock/-/rwlock-5.0.0.tgz",
-      "integrity": "sha1-iI1qd6M1HMGiCSBO8u4XIgk4Ns8=",
-      "dev": true
+      "integrity": "sha1-iI1qd6M1HMGiCSBO8u4XIgk4Ns8="
     },
     "rxjs": {
       "version": "6.6.0",
@@ -3354,12 +3277,10 @@
       }
     },
     "ssb-db": {
-      "version": "20.2.2",
-      "resolved": "https://registry.npmjs.org/ssb-db/-/ssb-db-20.2.2.tgz",
-      "integrity": "sha512-Gfdss0LWdfkRSALCaT1ggE7FhwNaIl/NcY2RMC9BFt3SWP1QGJweDw4TsxIawpRQp7JxNN+WQKra/wtFSsfPig==",
-      "dev": true,
+      "version": "20.3.0",
+      "resolved": "https://registry.npmjs.org/ssb-db/-/ssb-db-20.3.0.tgz",
+      "integrity": "sha512-JOXCrS6k3+/kuOcFmZwc9vxPN55Czb7McFs5KEYA+/phykPwQ6e3hwjMT5YrVzSirCf8ptPS/mpOsCDog5Z2dg==",
       "requires": {
-        "async-write": "^2.1.0",
         "flumedb": "^2.1.8",
         "flumelog-offset": "^3.4.2",
         "flumeview-level": "^4.0.4",
@@ -3412,7 +3333,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/ssb-msgs/-/ssb-msgs-5.2.0.tgz",
       "integrity": "sha1-xoHaXNcMV0ySLcpPA8UhU4E1wkM=",
-      "dev": true,
       "requires": {
         "ssb-ref": "^2.0.0"
       }
@@ -3464,7 +3384,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/ssb-validate/-/ssb-validate-4.1.1.tgz",
       "integrity": "sha512-3OsB6qTYlOMUqy4S1i0NuBtiqRW0s9z1Uf+Yqhjcqt7Zu8LTZk59HyhB1gfYmC3xzR/UnHeI7LkJZOt2+r//gA==",
-      "dev": true,
       "requires": {
         "is-canonical-base64": "^1.1.1",
         "monotonic-timestamp": "0.0.9",
@@ -3554,7 +3473,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.1.tgz",
       "integrity": "sha512-LRPxFUaTtpqYsTeNKaFOw3R4bxIzWOnbQ837QfBylo8jIxtcbK/A/sMV7Q+OAV/vWo+7s25pOE10KYSjaSO06g==",
-      "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.5"
@@ -3564,7 +3482,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.1.tgz",
       "integrity": "sha512-XxZn+QpvrBI1FOcg6dIpxUPgWCPuNXvMD72aaRaUQv1eD4e/Qy8i/hFTe0BUmD60p/QA6bh1avmuPTfNjqVWRw==",
-      "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.5"
@@ -3959,8 +3876,7 @@
     "uint48be": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/uint48be/-/uint48be-2.0.1.tgz",
-      "integrity": "sha512-LQvWofTo3RCz+XaQR3VNch+dDFwpIvWr/98imhQne++vFhpQP16YAC/a8w9N00Heqqra00ACjHT18cgvn5H+bg==",
-      "dev": true
+      "integrity": "sha512-LQvWofTo3RCz+XaQR3VNch+dDFwpIvWr/98imhQne++vFhpQP16YAC/a8w9N00Heqqra00ACjHT18cgvn5H+bg=="
     },
     "ultron": {
       "version": "1.0.2",
@@ -4061,8 +3977,7 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "write": {
       "version": "1.0.3",
@@ -4102,8 +4017,7 @@
     "zerr": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/zerr/-/zerr-1.0.4.tgz",
-      "integrity": "sha1-YoFN15nv+DYfKiKPQfcFxeGd5Mk=",
-      "dev": true
+      "integrity": "sha1-YoFN15nv+DYfKiKPQfcFxeGd5Mk="
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ssb-tribes",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ssb-tribes",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "a scuttlebutt (secret-stack) plugin which adds envelope encryption capabilities",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Builds on top of #18, depends on https://github.com/ssbc/ssb-db/pull/312.

---

Problem: The 'previous' observable changing our state each time that a
message is queued, but we don't actually care about the value except
when we're publishing a message with SSB-Tribes. This means that we have
a stream open (and eventually need to implement reconnect stuff) and
relies on global mutable state that's passed around through the app.

Solution: Remove the 'previous' listener and state, and instead expect
SSB-DB to pass the relevant feed metadata to the boxer. If we're
publishing a message without the autoboxer, like the group init, we can
look up the data we need instead of trying to maintain an in-memory
database of the most recent message.