### PR TITLE
more reliable group/add-member listener

### DIFF
--- a/index.js
+++ b/index.js
@@ -71,7 +71,7 @@ function init (ssb, config) {
   }
 
   /* start listeners */
-  listen.addMember(ssb)(m => {
+  listen.addMember(ssb, m => {
     const { root, groupKey } = m.value.content
     ssb.get({ id: root, meta: true }, (err, groupInitMsg) => {
       if (err) throw err

--- a/package-lock.json
+++ b/package-lock.json
@@ -170,24 +170,22 @@
     "async-single": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/async-single/-/async-single-1.0.5.tgz",
-      "integrity": "sha1-El3QneldPqMKN4rb7QIQkhebA8k=",
-      "dev": true
+      "integrity": "sha1-El3QneldPqMKN4rb7QIQkhebA8k="
     },
     "atomic-file": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/atomic-file/-/atomic-file-2.0.1.tgz",
-      "integrity": "sha512-9JCWojeLDF8UhEv2UJlLlPGsLEs+EBnfB+kOhsvmFI2QilVrnIsAwr7YnF8lLEVuxB+HxFhvGK+ax0Y8Eh/BKA==",
-      "dev": true,
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/atomic-file/-/atomic-file-2.1.0.tgz",
+      "integrity": "sha512-RF/2h7FQYY4zhWPjeAKFDS171G6pe0myu/koUEj3/8LVe4qWgPnOzGR2m4G3iZ/md5puWrq7tHDeZY9WzLf20g==",
       "requires": {
         "flumecodec": "0.0.1",
-        "idb-kv-store": "^4.4.0"
+        "idb-kv-store": "^4.5.0",
+        "mutexify": "^1.2.0"
       },
       "dependencies": {
         "flumecodec": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/flumecodec/-/flumecodec-0.0.1.tgz",
           "integrity": "sha1-rgSacUOGu4PjQmV6gpJLcDZKkNY=",
-          "dev": true,
           "requires": {
             "level-codec": "^6.2.0"
           }
@@ -195,8 +193,7 @@
         "level-codec": {
           "version": "6.2.0",
           "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-6.2.0.tgz",
-          "integrity": "sha1-pLUkS7akwvcj1oodZOmAxTYn2dQ=",
-          "dev": true
+          "integrity": "sha1-pLUkS7akwvcj1oodZOmAxTYn2dQ="
         }
       }
     },
@@ -476,7 +473,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
       "integrity": "sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==",
-      "dev": true,
       "requires": {
         "is-arguments": "^1.0.4",
         "is-date-object": "^1.0.1",
@@ -505,7 +501,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
       "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
-      "dev": true,
       "requires": {
         "object-keys": "^1.0.12"
       }
@@ -628,7 +623,6 @@
       "version": "1.17.6",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
       "integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
-      "dev": true,
       "requires": {
         "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
@@ -662,7 +656,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
       "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
-      "dev": true,
       "requires": {
         "is-callable": "^1.1.4",
         "is-date-object": "^1.0.1",
@@ -1121,7 +1114,6 @@
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/flumecodec/-/flumecodec-0.0.0.tgz",
       "integrity": "sha1-Ns4Gq+Lg4BxE3WnyoWUwWiMgZJs=",
-      "dev": true,
       "requires": {
         "level-codec": "^6.2.0"
       },
@@ -1129,8 +1121,7 @@
         "level-codec": {
           "version": "6.2.0",
           "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-6.2.0.tgz",
-          "integrity": "sha1-pLUkS7akwvcj1oodZOmAxTYn2dQ=",
-          "dev": true
+          "integrity": "sha1-pLUkS7akwvcj1oodZOmAxTYn2dQ="
         }
       }
     },
@@ -1257,7 +1248,6 @@
       "version": "1.3.17",
       "resolved": "https://registry.npmjs.org/flumeview-reduce/-/flumeview-reduce-1.3.17.tgz",
       "integrity": "sha512-Li09TntlRpN51GtFKllIh5nDdBcyDazvi5a/yvbdUCS9xAFb8OA6H6uu32W9gG+4GyvfUi9AsOyN8RQ8OcREQA==",
-      "dev": true,
       "requires": {
         "async-single": "^1.0.5",
         "atomic-file": "^2.0.0",
@@ -1292,8 +1282,7 @@
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
     "functional-red-black-tree": {
       "version": "1.0.1",
@@ -1370,7 +1359,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "dev": true,
       "requires": {
         "function-bind": "^1.1.1"
       }
@@ -1401,8 +1389,7 @@
     "has-symbols": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-      "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
-      "dev": true
+      "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
     },
     "hashlru": {
       "version": "2.3.0",
@@ -1432,10 +1419,9 @@
       }
     },
     "idb-kv-store": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/idb-kv-store/-/idb-kv-store-4.4.0.tgz",
-      "integrity": "sha1-IsVqjV+QvYj4GKhZ25xYYn3ieL4=",
-      "dev": true,
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/idb-kv-store/-/idb-kv-store-4.5.0.tgz",
+      "integrity": "sha512-snvtAQRforYUI+C2+45L2LBJy/0/uQUffxv8/uwiS98fSUoXHVrFPClgzWZWxT0drwkLHJRm9inZcYzTR42GLA==",
       "requires": {
         "inherits": "^2.0.3",
         "promisize": "^1.1.2"
@@ -1595,8 +1581,7 @@
     "is-arguments": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.0.4.tgz",
-      "integrity": "sha512-xPh0Rmt8NE65sNzvyUmWgI1tz3mKq74lGA0mL8LYZcoIzKOzDh6HmrYm3d18k60nHerC8A9Km8kYu87zfSFnLA==",
-      "dev": true
+      "integrity": "sha512-xPh0Rmt8NE65sNzvyUmWgI1tz3mKq74lGA0mL8LYZcoIzKOzDh6HmrYm3d18k60nHerC8A9Km8kYu87zfSFnLA=="
     },
     "is-arrayish": {
       "version": "0.2.1",
@@ -1619,8 +1604,7 @@
     "is-callable": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.0.tgz",
-      "integrity": "sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw==",
-      "dev": true
+      "integrity": "sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw=="
     },
     "is-canonical-base64": {
       "version": "1.1.1",
@@ -1630,8 +1614,7 @@
     "is-date-object": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
-      "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==",
-      "dev": true
+      "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g=="
     },
     "is-electron": {
       "version": "2.2.0",
@@ -1712,7 +1695,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.0.tgz",
       "integrity": "sha512-iI97M8KTWID2la5uYXlkbSDQIg4F6o1sYboZKKTDpnDQMLtUL86zxhgDet3Q2SriaYsyGqZ6Mn2SjbRKeLHdqw==",
-      "dev": true,
       "requires": {
         "has-symbols": "^1.0.1"
       }
@@ -1733,7 +1715,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
       "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
-      "dev": true,
       "requires": {
         "has-symbols": "^1.0.1"
       }
@@ -2155,6 +2136,11 @@
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
       "dev": true
     },
+    "mutexify": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/mutexify/-/mutexify-1.3.0.tgz",
+      "integrity": "sha512-WNPlgZ3AHETGSa4jeRP4aW6BPQ/a++MwoMFFIgrDg80+m70mbxuNOrevANfBDmur82zxTFAY3OwvMAvqrkV2sA=="
+    },
     "muxrpc": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/muxrpc/-/muxrpc-6.5.0.tgz",
@@ -2247,14 +2233,12 @@
     "object-inspect": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.8.0.tgz",
-      "integrity": "sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA==",
-      "dev": true
+      "integrity": "sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA=="
     },
     "object-is": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.2.tgz",
       "integrity": "sha512-5lHCz+0uufF6wZ7CRFWJN3hp8Jqblpgve06U5CMQ3f//6iDjPr2PEo9MWCjEssDsa+UZEL4PkFpr+BMop6aKzQ==",
-      "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.5"
@@ -2263,14 +2247,12 @@
     "object-keys": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-      "dev": true
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
     },
     "object.assign": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
       "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
-      "dev": true,
       "requires": {
         "define-properties": "^1.1.2",
         "function-bind": "^1.1.1",
@@ -2316,8 +2298,7 @@
     "obv": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/obv/-/obv-0.0.1.tgz",
-      "integrity": "sha1-yyNhBjQVNvDaxIFeBnCCIcrX+14=",
-      "dev": true
+      "integrity": "sha1-yyNhBjQVNvDaxIFeBnCCIcrX+14="
     },
     "obz": {
       "version": "1.0.2",
@@ -2632,8 +2613,7 @@
     "promisize": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/promisize/-/promisize-1.1.2.tgz",
-      "integrity": "sha1-m0fiyyrkl+seutwsQZHWTRXJSdE=",
-      "dev": true
+      "integrity": "sha1-m0fiyyrkl+seutwsQZHWTRXJSdE="
     },
     "prop-types": {
       "version": "15.7.2",
@@ -2796,7 +2776,6 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/pull-notify/-/pull-notify-0.1.1.tgz",
       "integrity": "sha1-b4b/ldJwuJw+vyVbYDG3Ay3JnMo=",
-      "dev": true,
       "requires": {
         "pull-pushable": "^2.0.0"
       }
@@ -2987,7 +2966,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.3.0.tgz",
       "integrity": "sha512-2+Q0C5g951OlYlJz6yu5/M33IcsESLlLfsyIaLJaG4FA2r4yP8MvVMJUUP/fVBkSpbbbZlS5gynbEWLipiiXiQ==",
-      "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.0-next.1"
@@ -3335,16 +3313,16 @@
       "dev": true
     },
     "ssb-backlinks": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/ssb-backlinks/-/ssb-backlinks-2.0.1.tgz",
-      "integrity": "sha512-20VjuN0/YBR04QEmcvHb9GsSQvYDMG6geY0f16FDBpjqfo9Ci5CGUao3f74o9FzUD2U0WklyhXdiMiAT9VKM4g==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ssb-backlinks/-/ssb-backlinks-2.1.0.tgz",
+      "integrity": "sha512-cXjPUxdFR3EUEBCxVDZ6HEIrx9DRwhlHOI5Rwatdkxj8EVgbSC+5KsqIp0XDJpOO5wEc5cO833ewy8TT3p8Z9g==",
       "dev": true,
       "requires": {
-        "base64-url": "^2.2.0",
-        "flumeview-links": "^2.0.1",
-        "pull-stream": "^3.6.7",
+        "base64-url": "^2.3.3",
+        "flumeview-links": "^2.1.0",
+        "pull-stream": "^3.6.14",
         "ssb-keys": "^7.0.14",
-        "ssb-ref": "^2.9.0"
+        "ssb-ref": "^2.14.0"
       }
     },
     "ssb-db": {
@@ -3547,7 +3525,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.1.tgz",
       "integrity": "sha512-LRPxFUaTtpqYsTeNKaFOw3R4bxIzWOnbQ837QfBylo8jIxtcbK/A/sMV7Q+OAV/vWo+7s25pOE10KYSjaSO06g==",
-      "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.5"
@@ -3557,7 +3534,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.1.tgz",
       "integrity": "sha512-XxZn+QpvrBI1FOcg6dIpxUPgWCPuNXvMD72aaRaUQv1eD4e/Qy8i/hFTe0BUmD60p/QA6bh1avmuPTfNjqVWRw==",
-      "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.5"

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "charwise": "^3.0.1",
     "envelope-js": "^0.1.2",
     "envelope-spec": "github:ssbc/envelope-spec",
+    "flumeview-reduce": "^1.3.17",
     "futoin-hkdf": "^1.3.2",
     "is-my-ssb-valid": "^1.1.0",
     "level": "^6.0.1",
@@ -35,7 +36,7 @@
   "devDependencies": {
     "is-canonical-base64": "^1.1.1",
     "scuttle-testbot": "^1.2.3 ",
-    "ssb-backlinks": "^2.0.1",
+    "ssb-backlinks": "^2.1.0",
     "ssb-query": "^2.4.5",
     "standard": "^14.3.4",
     "tap-spec": "^5.0.0",

--- a/test/listen.test.js
+++ b/test/listen.test.js
@@ -1,7 +1,6 @@
 const test = require('tape')
 const pull = require('pull-stream')
 
-const listen = require('../listen')
 const { Server } = require('./helpers')
 
 test('listen.addMember', t => {
@@ -16,35 +15,20 @@ test('listen.addMember', t => {
   // NOTE with auto-rebuild active, this listener gets hit twice:
   // 1. first time we see group/add-member (unboxed with DM key)
   // 2. after rebuild
-  listen.addMember(A)(m => {
+  function checkRebuildDone (done) {
+    if (A.status().sync.sync) return done()
+
+    console.log('waiting for rebuild')
+    setTimeout(() => checkRebuildDone(done), 500)
+  }
+  A.on('group/add-member', m => {
     t.equal(m.value.content.root, root, `listened + heard the group/add-member: ${++heardCount}`)
 
-    if (heardCount <= 2) {
-      t.pass(`addMember called ${heardCount} times`)
-    } else {
-      t.fail(`addMember called ${heardCount} times`)
-    }
-
     if (heardCount === 2) {
-      // HACK: This avoids a race condition where we close the database when
-      // the rebuild is still in progress. The double-get() is meant to be
-      // slow. The sequence of events should look like this:
-      //
-      // - main: get(root)
-      // - test: get(key)
-      // - main: rebuild()
-      // - test: get(key)
-      //   - this doesn't call back until indexes are up-to-date
-      // - main: rebuild finishes
-      // - test: get finishes
-      // - test: close server
-      // - test: end
-      //
-      A.get(m.key, (err) => {
-        t.error(err)
-        A.get(m.key, (err) => {
-          t.error(err)
-          A.close(t.end)
+      checkRebuildDone(() => {
+        A.close(err => {
+          t.error(err, 'A closed')
+          t.end()
         })
       })
     }
@@ -61,7 +45,7 @@ test('listen.addMember', t => {
     B.tribes.invite(groupId, [A.id], { text: 'ahoy' }, (err, invite) => {
       if (err) throw err
       messages.push(invite)
-      B.close()
+      B.close(err => t.error(err, 'closed B'))
 
       pull(
         pull.values(messages),

--- a/test/rebuild.test.js
+++ b/test/rebuild.test.js
@@ -4,32 +4,47 @@ const pull = require('pull-stream')
 const { Server } = require('./helpers')
 const { FeedId } = require('../lib/cipherlinks')
 
-function replicate ({ from, to, through = noop }) {
+function replicate ({ from, to, live = true, name = abbrev, through }, done) {
   pull(
-    from.createHistoryStream({ id: from.id, live: true }),
+    from.createHistoryStream({ id: from.id, live }),
     pull.through(through),
-    pull.drain(m => {
-      to.add(m.value, (err) => {
+    pull.asyncMap((m, cb) => to.add(m.value, cb)),
+    pull.asyncMap((m, cb) => to.get({ id: m.key, private: true, meta: true }, cb)),
+    pull.drain(
+      m => {
+        const type = m.value.content.type || '?' // encrypted
+        const added = type === 'group/add-member'
+          ? `: ${m.value.content.recps.filter(r => r[0] === '@').map(name)}`
+          : ''
+        console.log(`${name(m.value.author)} -> ${name(to.id)}  |  ${abbrev(m.key)} ${type} ${added}`)
+      },
+      err => {
+        if (typeof done === 'function') return done(err)
         if (err) throw err
-        console.log(`replicated ${m.key}`)
-      })
-    })
+      }
+    )
   )
 }
-function noop () {}
-
-test('rebuild', t => {
-  const me = Server() // me
-  const admin = Server() // some friend
-
-  var messages = []
-  replicate({
-    from: admin,
-    to: me,
-    through: m => messages.push(m.key)
+function abbrev (key) { return key.slice(0, 9) }
+function nMessages (n, { type = 'post', recps } = {}) {
+  return new Array(20).fill(type).map((val, i) => {
+    const content = { type, count: i }
+    if (recps) content.recps = recps
+    return content
   })
+}
 
-  var groupId
+test('rebuild (I am added to a group)', t => {
+  const admin = Server()
+  const me = Server()
+  const name = (id) => {
+    switch (id) {
+      case admin.id: return 'admin'
+      case me.id: return 'me'
+    }
+  }
+
+  replicate({ from: admin, to: me, name })
 
   me.rebuild.hook(function (rebuild, [cb]) {
     t.pass('I automatically call a rebuild')
@@ -42,7 +57,7 @@ test('rebuild', t => {
         me.createUserStream({ id: admin.id, private: true }),
         pull.drain(
           m => {
-            t.equal(typeof m.value.content, 'object', `I auto-unbox msg of type: ${m.value.content.type}`)
+            t.equal(typeof m.value.content, 'object', `I auto-unbox msg: ${m.value.content.type}`)
           },
           (err) => {
             if (err) throw err
@@ -59,11 +74,111 @@ test('rebuild', t => {
   admin.tribes.create({}, (err, data) => {
     if (err) throw err
 
-    groupId = data.groupId
-    console.log(`created group: ${groupId}`)
-
-    admin.tribes.invite(groupId, [me.id], { text: 'ahoy' }, (err, invite) => {
+    admin.tribes.invite(data.groupId, [me.id], { text: 'ahoy' }, (err, invite) => {
       t.error(err, 'admin adds me to group')
+      if (err) throw err
+    })
+  })
+})
+
+test('rebuild (I am added to a group)', t => {
+  const admin = Server()
+  const alice = Server()
+  const bob = Server()
+  const name = (id) => {
+    switch (id) {
+      case admin.id: return 'admin'
+      case alice.id: return 'alice'
+      case bob.id: return 'bob  '
+    }
+  }
+
+  var groupId
+  replicate({ from: admin, to: alice, name })
+  replicate({ from: admin, to: bob, name })
+
+  alice.rebuild.hook(function (rebuild, [cb]) {
+    rebuild(() => {
+      t.pass('alice is in the group')
+
+      cb()
+      pull(
+        pull.values(nMessages(20, { type: 'alice', recps: [groupId] })),
+        pull.asyncMap(alice.publish),
+        pull.collect((err) => {
+          t.error(err, 'alice publishes to the group')
+
+          replicate({ from: alice, to: bob, name, live: false }, (err) => {
+            t.error(err, 'bob has received all of admin + alices messages to date')
+            alice.close()
+            // NOTE: we close alice here to stop her from re-indexing
+            // when we add bob is added to the group
+            // If you close while rebuilding, you get a segmentation fault
+            admin.tribes.invite(groupId, [bob.id], { text: 'hi!' }, (err) => {
+              t.error(err, 'admin adds bob to the group')
+            })
+          })
+        })
+      )
+    })
+  })
+
+  var rebuildCount = 0
+  bob.rebuild.hook(function (rebuild, [cb]) {
+    const _count = ++rebuildCount
+
+    switch (_count) {
+      case 1:
+        t.pass('bob calls rebuild (added to group)')
+        break
+      case 2:
+        t.pass('bob calls rebuild (realises alice is in group)')
+        break
+      default:
+        t.fail(`rebuild called to many times: ${_count}`)
+    }
+
+    rebuild(() => {
+      cb()
+      if (_count !== 2) return
+
+      let seenAlices = 0
+      pull(
+        bob.createLogStream({ private: true }),
+        pull.map(m => m.value.content),
+        pull.drain(
+          ({ type, count, recps }) => {
+            let comment = `bob auto-unboxes: ${type} `
+
+            if (type === 'group/add-member') {
+              comment += `: ${recps.filter(r => r[0] === '@').map(name)}`
+            }
+            if (type === 'alice') {
+              seenAlices++
+              if (count === 0 || count === 19) comment += `(${count})`
+              else if (count === 1) comment += '...'
+              else return
+            }
+            t.true(type, comment)
+          },
+          (err) => {
+            if (seenAlices === 20) t.equal(seenAlices, 20, 'saw 20 messages from alice')
+            if (err) throw err
+            bob.close()
+            admin.close()
+            t.end()
+          }
+        )
+      )
+    })
+  })
+
+  admin.tribes.create({}, (err, data) => {
+    if (err) throw err
+
+    groupId = data.groupId
+    admin.tribes.invite(groupId, [alice.id], { text: 'ahoy' }, (err) => {
+      t.error(err, 'admin adds alice to group')
       if (err) throw err
     })
   })


### PR DESCRIPTION
This changes how we're listening for new `group/add-member` messages.
It's more resilient to random shutdowns (I think ...) and as it uses a flume view it tracks which messages it's processed, so should be much faster (rather than streaming through the whole database on every startup!)

hmmm mind you the `messagesByType` isn't streaming through the whole db, it's only picking up the messages of type `group/add-member`. I'm now not so sure this is needed, I think I want to sleep on it.